### PR TITLE
use python2 tinstead of python to run waf

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -27,7 +27,7 @@ $(SHLIB): libbgen.a libzstd.a
 
 
 libbgen.a: $(BGEN_VERSION)
-	cd $(BGEN_VERSION) && ./waf configure && ./waf
+	cd $(BGEN_VERSION) && python2 ./waf configure && python2 ./waf
 	cp -f $(BGEN_VERSION)/build/libbgen.a .
 	cp -f $(BGEN_VERSION)/build/3rd_party/zstd-1.1.0/libzstd.a .
 	rm -rf $(BGEN_VERSION)/build


### PR DESCRIPTION
I believe the wscript file for bgen requires python 2.  On machines where `python` is a newer version of python, right now you get something like:  `Waf: The wscript in '/tmp/RtmpIUKio5/R.INSTALLc590a745c77b3/gds2bgen/src/gavinband-bgen-0b7a2803adb5' is unreadable`.  I think adding the explicit `python2` fixes that.  There's also something funny going on where`waf` correctly detects the C++ compiler that R uses, but doesn't reliably detect the C compiler, and instead uses the system C compiler.  Somehow this hasn't caused any problems yet for me so I haven't made any changes in that regard.
